### PR TITLE
[PKG-4851] Standardizing recipe.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "pypng" %}
 {% set version = "0.20220715.0" %}
-{% set sha256 = "739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: {{ 739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1 }}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ 739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1 }}
+  sha256: 739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,26 @@
 {% set name = "pypng" %}
 {% set version = "0.20220715.0" %}
+{% set sha256 = "739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://gitlab.com/drj11/pypng/-/archive/pypng-{{ version }}/pypng-pypng-{{ version }}.tar.bz2
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: cbcf24b25951bc8694cdbcf67ffeda6294b52109db3d02a90dd1a0ade69ebcaa
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -32,6 +34,9 @@ about:
   license_family: MIT
   license_file: LICENCE
   summary: Pure Python PNG image encoder and decoder
+  description: PNG module for Python. PyPNG is written entirely in Python.
+  dev_url: https://gitlab.com/drj11/pypng/
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,10 @@ requirements:
 test:
   imports:
     - png
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://gitlab.com/drj11/pypng/
@@ -36,6 +40,7 @@ about:
   summary: Pure Python PNG image encoder and decoder
   description: PNG module for Python. PyPNG is written entirely in Python.
   dev_url: https://gitlab.com/drj11/pypng/
+  doc_url: https://gitlab.com/drj11/pypng/-/blob/main/README.md
 
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cbcf24b25951bc8694cdbcf67ffeda6294b52109db3d02a90dd1a0ade69ebcaa
+  sha256: {{ sha256 }}
 
 build:
   number: 0


### PR DESCRIPTION
{package} {version} {:snowflake:}

**Destination channel:** {defaults}

### Links

- [Upstream repository](https://gitlab.com/drj11/pypng/)
- [issue](https://anaconda.atlassian.net/browse/PKG-4851)
### Explanation of changes:
- Pointing to PyPI instead of source
- Changing hash
- Making it not no arch
